### PR TITLE
Remove unnecessary enum in link queries

### DIFF
--- a/lib/card.js
+++ b/lib/card.js
@@ -60,7 +60,7 @@ const getLinkQuery = (verb, fromCard, toCard = null) => {
 			},
 			type: {
 				type: 'string',
-				enum: [ 'link', 'link@1.0.0' ]
+				const: 'link@1.0.0'
 			},
 			active: {
 				type: 'boolean',


### PR DESCRIPTION
This change additionally allows the jellyfish backend to take advantage of partial indexes.

Fixes product-os/jellyfish-client-sdk#9

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>