### PR TITLE
Fix uuid require statements

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -4,7 +4,9 @@
  * Proprietary and confidential.
  */
 
-const uuid = require('uuid/v4')
+const {
+	v4: uuid
+} = require('uuid')
 
 /**
  * @namespace JellyfishSDK.auth

--- a/lib/card.js
+++ b/lib/card.js
@@ -11,7 +11,9 @@ const Bluebird = require('bluebird')
 const clone = require('deep-copy')
 const jsonpatch = require('fast-json-patch')
 const _ = require('lodash')
-const uuid = require('uuid/v4')
+const {
+	v4: uuid
+} = require('uuid')
 const isUUID = require('isuuid')
 
 const checkLinksExist = async (sdk, verb, fromCard, toCard = null) => {

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -7,7 +7,9 @@
 const ava = require('ava')
 const Bluebird = require('bluebird')
 const _ = require('lodash')
-const uuid = require('uuid')
+const {
+	v4: uuid
+} = require('uuid')
 const {
 	getSdk
 } = require('./index')
@@ -58,7 +60,7 @@ ava.serial('.action() should send an action to the server', async (test) => {
 		sdk
 	} = test.context
 
-	const name = `test-card-${uuid.v4()}`
+	const name = `test-card-${uuid()}`
 
 	const server = nock(API_URL)
 
@@ -122,7 +124,7 @@ ava.serial('.query() should send a query to the server', async (test) => {
 		sdk
 	} = test.context
 
-	const name = `test-card-${uuid.v4()}`
+	const name = `test-card-${uuid()}`
 
 	const server = nock(API_URL)
 
@@ -212,7 +214,7 @@ ava.serial('.card.get() should work for ids', async (test) => {
 		sdk
 	} = test.context
 
-	const name = `test-card-${uuid.v4()}`
+	const name = `test-card-${uuid()}`
 	const id = '37a55e52-23fb-4122-8d4e-319827232278'
 
 	const mockData = {
@@ -255,7 +257,7 @@ ava.serial('.card.get() should work for slugs', async (test) => {
 		sdk
 	} = test.context
 
-	const name = `test-card-${uuid.v4()}`
+	const name = `test-card-${uuid()}`
 	const slug = 'test-card-37a55e52-23fb-4122-8d4e-319827232278'
 
 	const mockData = {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -6,7 +6,9 @@
 
 const _ = require('lodash')
 const io = require('socket.io-client')
-const uuid = require('uuid/v4')
+const {
+	v4: uuid
+} = require('uuid')
 
 /**
  * @class JellyfishStreamManager


### PR DESCRIPTION
This removes a warning message about how uuid v4 is required. Ref: https://github.com/uuidjs/uuid#deep-requires-now-deprecated

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>