### PR TITLE
Add support for 'is owned by' links for sales threads

### DIFF
--- a/lib/link-constraints.js
+++ b/lib/link-constraints.js
@@ -269,6 +269,26 @@ exports.constraints = [
 		}
 	},
 	{
+		slug: 'link-constraint-sales-thread-is-owned-by',
+		name: 'is owned by',
+		data: {
+			title: 'Owner',
+			from: 'sales-thread',
+			to: 'user',
+			inverse: 'link-constraint-user-is-owner-of-sales-thread'
+		}
+	},
+	{
+		slug: 'link-constraint-user-is-owner-of-sales-thread',
+		name: 'is owner of',
+		data: {
+			title: 'Sales thread',
+			from: 'user',
+			to: 'sales-thread',
+			inverse: 'link-constraint-sales-thread-is-owned-by'
+		}
+	},
+	{
 		slug: 'link-constraint-sales-thread-is-attached-to-opportunity',
 		name: 'is attached to',
 		data: {


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

Very simple addition to add ownership for sales threads.