### PR TITLE
Add support for marking as read if user's group is mentioned

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ const card = await sdk.card.get('b1d31eca-6182-4c34-8a74-f89f1c3e4e26')
         * [.remove(id, type)](#JellyfishSDK.card.remove) ⇒ <code>Promise</code>
         * [.link(fromCard, toCard, verb)](#JellyfishSDK.card.link) ⇒ <code>Promise</code>
         * [.unlink(fromCard, toCard, verb)](#JellyfishSDK.card.unlink) ⇒ <code>Promise</code>
-        * [.markAsRead(userSlug, card)](#JellyfishSDK.card.markAsRead) ⇒ <code>Promise</code>
-        * [.markAsUnread(userSlug, card)](#JellyfishSDK.card.markAsUnread) ⇒ <code>Promise</code>
+        * [.markAsRead(userSlug, card, userGroups)](#JellyfishSDK.card.markAsRead) ⇒ <code>Promise</code>
+        * [.markAsUnread(userSlug, card, userGroups)](#JellyfishSDK.card.markAsUnread) ⇒ <code>Promise</code>
     * [.event](#JellyfishSDK.event) : <code>object</code>
         * [.create(event)](#JellyfishSDK.event.create) ⇒ <code>Promise</code>
     * [.getConfig()](#JellyfishSDK.getConfig) ⇒ <code>Promise</code>
@@ -241,8 +241,8 @@ sdk.auth.logout()
     * [.remove(id, type)](#JellyfishSDK.card.remove) ⇒ <code>Promise</code>
     * [.link(fromCard, toCard, verb)](#JellyfishSDK.card.link) ⇒ <code>Promise</code>
     * [.unlink(fromCard, toCard, verb)](#JellyfishSDK.card.unlink) ⇒ <code>Promise</code>
-    * [.markAsRead(userSlug, card)](#JellyfishSDK.card.markAsRead) ⇒ <code>Promise</code>
-    * [.markAsUnread(userSlug, card)](#JellyfishSDK.card.markAsUnread) ⇒ <code>Promise</code>
+    * [.markAsRead(userSlug, card, userGroups)](#JellyfishSDK.card.markAsRead) ⇒ <code>Promise</code>
+    * [.markAsUnread(userSlug, card, userGroups)](#JellyfishSDK.card.markAsUnread) ⇒ <code>Promise</code>
 
 <a name="JellyfishSDK.card.get"></a>
 
@@ -452,8 +452,8 @@ Un-link two cards
 
 <a name="JellyfishSDK.card.markAsRead"></a>
 
-#### card.markAsRead(userSlug, card) ⇒ <code>Promise</code>
-Link two cards together
+#### card.markAsRead(userSlug, card, userGroups) ⇒ <code>Promise</code>
+Adds the user slug to the data.readBy field of the card.
 
 **Kind**: static method of [<code>card</code>](#JellyfishSDK.card)  
 **Summary**: Mark a card as read  
@@ -463,11 +463,12 @@ Link two cards together
 | --- | --- | --- |
 | userSlug | <code>String</code> | The slug of the user who has read the card |
 | card | <code>String</code> | The card that should be marked as read |
+| userGroups | <code>Array</code> | An array of groups that the user is a member of |
 
 <a name="JellyfishSDK.card.markAsUnread"></a>
 
-#### card.markAsUnread(userSlug, card) ⇒ <code>Promise</code>
-Link two cards together
+#### card.markAsUnread(userSlug, card, userGroups) ⇒ <code>Promise</code>
+Removes the user slug from the data.readBy field of the card.
 
 **Kind**: static method of [<code>card</code>](#JellyfishSDK.card)  
 **Summary**: Mark a card as unread  
@@ -477,6 +478,7 @@ Link two cards together
 | --- | --- | --- |
 | userSlug | <code>String</code> | The slug of the user who has read the card |
 | card | <code>String</code> | The card that should be marked as unread |
+| userGroups | <code>Array</code> | An array of groups that the user is a member of |
 
 <a name="JellyfishSDK.event"></a>
 

--- a/lib/card.js
+++ b/lib/card.js
@@ -106,6 +106,12 @@ const getLinkQuery = (verb, fromCard, toCard = null) => {
 	return query
 }
 
+exports.isMentionedInMessage = (message, userSlug, userGroups = []) => {
+	const mentionsUser = message.match(new RegExp(`(\\s|^)[!@]${userSlug.slice(5)}`))
+	const mentionsGroup = userGroups.length && message.match(new RegExp(`(\\s|^)(!!|@@)(${userGroups.join('|')})`))
+	return Boolean(mentionsUser || mentionsGroup)
+}
+
 /**
  * @namespace JellyfishSDK.card
  * @memberof JellyfishSDK
@@ -615,14 +621,15 @@ class CardSdk {
 	 * @function
 	 * @memberof JellyfishSDK.card
 	 *
-	 * @description Link two cards together
+	 * @description Adds the user slug to the data.readBy field of the card.
 	 *
 	 * @param {String} userSlug - The slug of the user who has read the card
 	 * @param {String} card - The card that should be marked as read
+	 * @param {Array} userGroups - An array of groups that the user is a member of
 	 *
 	 * @returns {Promise}
 	 */
-	async markAsRead (userSlug, card) {
+	async markAsRead (userSlug, card, userGroups = []) {
 		const typeBase = card.type.split('@')[0]
 		if (typeBase !== 'message' && typeBase !== 'whisper' && typeBase !== 'summary') {
 			throw new Error(
@@ -630,10 +637,10 @@ class CardSdk {
 			)
 		}
 
-		const message = _.get(card, [ 'data', 'payload', 'message' ], '')
+		const message = _.get(card, [ 'data', 'payload', 'message' ], '').toLowerCase()
 
-		// Only continue if the message mentions the current user
-		if (message.toLowerCase().includes(`@${userSlug.slice(5)}`) || message.toLowerCase().includes(`!${userSlug.slice(5)}`)) {
+		// Only continue if the message mentions the current user or a group they are part of
+		if (exports.isMentionedInMessage(message, userSlug, userGroups)) {
 			const readBy = _.get(card, [ 'data', 'readBy' ], [])
 
 			if (!_.includes(readBy, userSlug)) {
@@ -660,14 +667,15 @@ class CardSdk {
 	 * @function
 	 * @memberof JellyfishSDK.card
 	 *
-	 * @description Link two cards together
+	 * @description Removes the user slug from the data.readBy field of the card.
 	 *
 	 * @param {String} userSlug - The slug of the user who has read the card
 	 * @param {String} card - The card that should be marked as unread
+	 * @param {Array} userGroups - An array of groups that the user is a member of
 	 *
 	 * @returns {Promise}
 	 */
-	async markAsUnread (userSlug, card) {
+	async markAsUnread (userSlug, card, userGroups = []) {
 		const typeBase = card.type.split('@')[0]
 		if (typeBase !== 'message' && typeBase !== 'whisper' && typeBase !== 'summary') {
 			throw new Error(
@@ -675,10 +683,10 @@ class CardSdk {
 			)
 		}
 
-		const message = _.get(card, [ 'data', 'payload', 'message' ], '')
+		const message = _.get(card, [ 'data', 'payload', 'message' ], '').toLowerCase()
 
 		// Only continue if the message mentions the current user
-		if (message.includes(`@${userSlug.slice(5)}`) || message.includes(`!${userSlug.slice(5)}`)) {
+		if (exports.isMentionedInMessage(message, userSlug, userGroups)) {
 			const readBy = _.get(card, [ 'data', 'readBy' ], [])
 
 			if (_.includes(readBy, userSlug)) {

--- a/lib/card.spec.js
+++ b/lib/card.spec.js
@@ -6,16 +6,89 @@
 
 const ava = require('ava')
 const _ = require('lodash')
+const sinon = require('sinon')
 const {
 	v4: uuid
 } = require('uuid')
 const {
 	getSdk
 } = require('./index')
+const {
+	isMentionedInMessage,
+	CardSdk
+} = require('./card')
 
 const nock = require('nock')
 
 const API_URL = 'https://test.ly.fish'
+
+const testMarkAsReadMention = async (test, message, userSlug, userGroups, expectMention = true) => {
+	const sdk = {
+		card: {
+			update: sinon.fake.resolves(null)
+		}
+	}
+	const cardSdk = new CardSdk(sdk)
+	const card = {
+		id: 'msg1',
+		type: 'message@1.0.0',
+		data: {
+			payload: {
+				message
+			}
+		}
+	}
+
+	await cardSdk.markAsRead(userSlug, card, userGroups)
+
+	if (expectMention) {
+		test.true(sdk.card.update.calledOnce)
+		test.deepEqual(sdk.card.update.getCall(0).args[2], [
+			{
+				op: 'add',
+				path: '/data/readBy',
+				value: [
+					'user-testuser'
+				]
+			}
+		])
+	} else {
+		test.true(sdk.card.update.notCalled)
+	}
+}
+
+const testMarkAsUnreadMention = async (test, message, userSlug, userGroups, expectMention = true) => {
+	const sdk = {
+		card: {
+			update: sinon.fake.resolves(null)
+		}
+	}
+	const cardSdk = new CardSdk(sdk)
+	const card = {
+		id: 'msg1',
+		type: 'message@1.0.0',
+		data: {
+			readBy: [ userSlug ],
+			payload: {
+				message
+			}
+		}
+	}
+
+	await cardSdk.markAsUnread(userSlug, card, userGroups)
+
+	if (expectMention) {
+		test.true(sdk.card.update.calledOnce)
+		test.deepEqual(sdk.card.update.getCall(0).args[2], [
+			{
+				op: 'remove',
+				path: '/data/readBy/0'
+			}
+		])
+	} else {
+		test.true(sdk.card.update.notCalled)
+	}
+}
 
 ava.serial.before(async (test) => {
 	test.context.sdk = getSdk({
@@ -184,4 +257,74 @@ ava.serial('getWithTimeline merges the schema options with the default query sch
 	}
 	)
 	test.is(getWithTimelineRequest.name, name)
+})
+
+ava('markAsRead updates the card if the user is mentioned directly', async (test) => {
+	await testMarkAsReadMention(test, 'Hello @testuser', 'user-testuser')
+})
+
+ava('markAsRead updates the card if the user is alerted directly', async (test) => {
+	await testMarkAsReadMention(test, 'Hello !testuser', 'user-testuser')
+})
+
+ava('markAsRead updates the card if a group the user is part of is mentioned', async (test) => {
+	await testMarkAsReadMention(test, 'Hello @@group1', 'user-testuser', [ 'group1' ])
+})
+
+ava('markAsRead updates the card if a group the user is part of is alerted', async (test) => {
+	await testMarkAsReadMention(test, 'Hello !!group1', 'user-testuser', [ 'group1' ])
+})
+
+ava('markAsRead does not update the card if the user is not mentioned', async (test) => {
+	await testMarkAsReadMention(test, 'Hello @some-other-user @@some-other-group', 'user-testuser', [ 'group1' ], false)
+})
+
+ava('markAsUnread updates the card if the user is mentioned directly', async (test) => {
+	await testMarkAsUnreadMention(test, 'Hello @testuser', 'user-testuser')
+})
+
+ava('markAsUnread updates the card if the user is alerted directly', async (test) => {
+	await testMarkAsUnreadMention(test, 'Hello !testuser', 'user-testuser')
+})
+
+ava('markAsUnread updates the card if a group the user is part of is mentioned', async (test) => {
+	await testMarkAsUnreadMention(test, 'Hello @@group1', 'user-testuser', [ 'group1' ])
+})
+
+ava('markAsUnread updates the card if a group the user is part of is alerted', async (test) => {
+	await testMarkAsUnreadMention(test, 'Hello !!group1', 'user-testuser', [ 'group1' ])
+})
+
+ava('markAsUnread does not update the card if the user is not mentioned', async (test) => {
+	await testMarkAsUnreadMention(test, 'Hello @some-other-user @@some-other-group', 'user-testuser', [ 'group1' ], false)
+})
+
+ava('isMentionedInMessage filters for user and group mentions and alerts', async (test) => {
+	// Users are identified
+	test.true(isMentionedInMessage('@test-user', 'user-test-user'))
+	test.true(isMentionedInMessage('Hi @test-user', 'user-test-user'))
+	test.true(isMentionedInMessage('!test-user', 'user-test-user'))
+	test.true(isMentionedInMessage('Hi !test-user', 'user-test-user'))
+
+	// Groups are identified
+	test.true(isMentionedInMessage('@@test-group', 'user-test-user', [ 'test-group' ]))
+	test.true(isMentionedInMessage('Hi @@test-group', 'user-test-user', [ 'test-group' ]))
+	test.true(isMentionedInMessage('!!test-group', 'user-test-user', [ 'test-group' ]))
+	test.true(isMentionedInMessage('Hi !!test-group', 'user-test-user', [ 'test-group' ]))
+
+	// Users and groups are not confused
+	test.false(isMentionedInMessage('@@test-user', 'user-test-user'))
+	test.false(isMentionedInMessage('!!test-user', 'user-test-user'))
+	test.false(isMentionedInMessage('@test-group', 'user-test-user', [ 'test-group' ]))
+	test.false(isMentionedInMessage('!test-group', 'user-test-user', [ 'test-group' ]))
+
+	// Token must be preceded by a space or be at the start of the string
+	test.false(isMentionedInMessage('Hi@test-user', 'user-test-user'))
+	test.false(isMentionedInMessage('Hi!test-user', 'user-test-user'))
+	test.false(isMentionedInMessage('Hi@@test-group', 'user-test-user', [ 'test-group' ]))
+	test.false(isMentionedInMessage('Hi!!test-group', 'user-test-user', [ 'test-group' ]))
+
+	// Tokens that don't match are not identified
+	test.false(isMentionedInMessage('Hi @testuse', 'user-test-user'))
+	test.false(isMentionedInMessage('Hi @@tetgroup', 'user-test-user', [ 'test-group' ]))
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,51 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.0.tgz",
+      "integrity": "sha512-wEj54PfsZ5jGSwMX68G8ZXFawcSglQSXqCftWX3ec8MDUzQdHgcKvw97awHbY0efQEL5iKUOAmmVtoYgmrSG4Q==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
+      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -1159,6 +1204,12 @@
           }
         }
       }
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -2679,6 +2730,12 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -2774,6 +2831,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.islength": {
@@ -3047,6 +3110,19 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
+      "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "nock": {
       "version": "12.0.3",
@@ -3349,6 +3425,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -3924,6 +4017,21 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "sinon": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
+      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.0.3",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4438,6 +4546,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "jsdoc-to-markdown": "^5.0.3",
-    "nock": "^12.0.3"
+    "nock": "^12.0.3",
+    "sinon": "^9.0.2"
   }
 }


### PR DESCRIPTION
Messages should be marked as read/unread if a group the user is part of is mentioned in the message.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

---

This update is needed in order for the 'read by' badge count to work on the group-mentions spans in Jellyfish messages (see [this PR](https://github.com/product-os/jellyfish/pull/4128)).

The update is backwards-compatible as the behaviour is unchanged if the new `userGroups` argument is not supplied.