### PR TITLE
link-constraints: Change name of support-thread -> support-issue relationship

### DIFF
--- a/lib/link-constraints.js
+++ b/lib/link-constraints.js
@@ -110,7 +110,7 @@ exports.constraints = [
 	},
 	{
 		slug: 'link-constraint-support-thread-is-attached-to-support-issue',
-		name: 'support thread is attached to support issue',
+		name: 'is attached to',
 		data: {
 			title: 'Support issue',
 			from: 'support-thread',
@@ -130,7 +130,7 @@ exports.constraints = [
 	},
 	{
 		slug: 'link-constraint-support-issue-has-attached-support-thread',
-		name: 'support issue has attached support thread',
+		name: 'has attached',
 		data: {
 			title: 'Support thread',
 			from: 'support-issue',


### PR DESCRIPTION
Associations with the type names encoded in them are a modelling error.  There is more than one of them present, but this change addresses only one - mainly to experimentally see how painful this change will be since we will have to synchronise the major version change with a PR in jellyfish too.

Change-type: major
Signed-off-by: James Harton <jamesh@balena.io>