### PR TITLE
card: add support for marking 1-to-1 conversations as read/unread

### DIFF
--- a/lib/card.js
+++ b/lib/card.js
@@ -106,10 +106,26 @@ const getLinkQuery = (verb, fromCard, toCard = null) => {
 	return query
 }
 
-exports.isMentionedInMessage = (message, userSlug, userGroups = []) => {
-	const mentionsUser = message.match(new RegExp(`(\\s|^)[!@]${userSlug.slice(5)}`))
-	const mentionsGroup = userGroups.length && message.match(new RegExp(`(\\s|^)(!!|@@)(${userGroups.join('|')})`))
-	return Boolean(mentionsUser || mentionsGroup)
+exports.isMentionedInMessage = (message, userSlug, userGroups = [], markers = []) => {
+	// First check for a direct mention
+	const userMentionRegExp = new RegExp(`(\\s|^)[!@]${userSlug.slice(5)}`)
+	if (message.match(userMentionRegExp)) {
+		return true
+	}
+
+	// Then check if one of the user's groups is mentioned
+	const groupMentionRegExp = new RegExp(`(\\s|^)(!!|@@)(${userGroups.join('|')})`)
+	if (userGroups.length && message.match(groupMentionRegExp)) {
+		return true
+	}
+
+	// Lastly check if the conversation is a 1-to-1 conversation involving that user
+	const userInMarkerRegExp = new RegExp(`(\\+|^)${userSlug}(\\+|$)`)
+	if (_.some(_.invokeMap(markers, 'match', userInMarkerRegExp))) {
+		return true
+	}
+
+	return false
 }
 
 /**
@@ -638,9 +654,10 @@ class CardSdk {
 		}
 
 		const message = _.get(card, [ 'data', 'payload', 'message' ], '').toLowerCase()
+		const markers = _.get(card, [ 'markers' ], [])
 
 		// Only continue if the message mentions the current user or a group they are part of
-		if (exports.isMentionedInMessage(message, userSlug, userGroups)) {
+		if (exports.isMentionedInMessage(message, userSlug, userGroups, markers)) {
 			const readBy = _.get(card, [ 'data', 'readBy' ], [])
 
 			if (!_.includes(readBy, userSlug)) {
@@ -684,9 +701,10 @@ class CardSdk {
 		}
 
 		const message = _.get(card, [ 'data', 'payload', 'message' ], '').toLowerCase()
+		const markers = _.get(card, [ 'markers' ], [])
 
 		// Only continue if the message mentions the current user
-		if (exports.isMentionedInMessage(message, userSlug, userGroups)) {
+		if (exports.isMentionedInMessage(message, userSlug, userGroups, markers)) {
 			const readBy = _.get(card, [ 'data', 'readBy' ], [])
 
 			if (_.includes(readBy, userSlug)) {

--- a/lib/card.spec.js
+++ b/lib/card.spec.js
@@ -299,7 +299,7 @@ ava('markAsUnread does not update the card if the user is not mentioned', async 
 	await testMarkAsUnreadMention(test, 'Hello @some-other-user @@some-other-group', 'user-testuser', [ 'group1' ], false)
 })
 
-ava('isMentionedInMessage filters for user and group mentions and alerts', async (test) => {
+ava('isMentionedInMessage filters for user and group mentions and alerts and 1-to-1 conversations', async (test) => {
 	// Users are identified
 	test.true(isMentionedInMessage('@test-user', 'user-test-user'))
 	test.true(isMentionedInMessage('Hi @test-user', 'user-test-user'))
@@ -327,4 +327,13 @@ ava('isMentionedInMessage filters for user and group mentions and alerts', async
 	// Tokens that don't match are not identified
 	test.false(isMentionedInMessage('Hi @testuse', 'user-test-user'))
 	test.false(isMentionedInMessage('Hi @@tetgroup', 'user-test-user', [ 'test-group' ]))
+
+	// 1-to-1 conversations with the user are identified
+	test.true(isMentionedInMessage('Hello', 'user-test-user', [], [ 'user-test-user' ]))
+	test.true(isMentionedInMessage('Hello', 'user-test-user', [], [ 'org-balena+user-test-user' ]))
+	test.true(isMentionedInMessage('Hello', 'user-test-user', [], [ 'some-other-marker', 'user-test-user+org-balena' ]))
+
+	// 1-to-1 conversations with similar users are not identified!
+	test.false(isMentionedInMessage('Hello', 'user-test-user', [], [ 'user-test-useri' ]))
+	test.false(isMentionedInMessage('Hello', 'user-test-user', [], [ 'user-test-user-' ]))
 })


### PR DESCRIPTION
Note - this logic uses the 'markers' field. It's not ideal but it works for now.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This change is needed before we can add 1-to-1 conversations to the inbox and mentions count - see [Jellyfish issue 4361](https://github.com/product-os/jellyfish/issues/4361)