### PR TITLE
Add link constraints for the brainstorm-call and brainstorm-topic cards

### DIFF
--- a/lib/link-constraints.js
+++ b/lib/link-constraints.js
@@ -479,23 +479,23 @@ exports.constraints = [
 		}
 	},
 	{
-		slug: 'link-constraint-discussion-topic-has-attached-issue',
+		slug: 'link-constraint-brainstorm-topic-has-attached-issue',
 		name: 'has attached',
 		data: {
 			title: 'GitHub issue',
-			from: 'discussion-topic',
+			from: 'brainstorm-topic',
 			to: 'issue',
-			inverse: 'link-constraint-issue-is-attached-to-discussion-topic'
+			inverse: 'link-constraint-issue-is-attached-to-brainstorm-topic'
 		}
 	},
 	{
-		slug: 'link-constraint-issue-is-attached-to-discussion-topic',
+		slug: 'link-constraint-issue-is-attached-to-brainstorm-topic',
 		name: 'is attached to',
 		data: {
-			title: 'Discussion topic',
+			title: 'Brainstorm topic',
 			from: 'issue',
-			to: 'discussion-topic',
-			inverse: 'link-constraint-discussion-topic-has-attached-issue'
+			to: 'brainstorm-topic',
+			inverse: 'link-constraint-brainstorm-topic-has-attached-issue'
 		}
 	},
 	{
@@ -519,43 +519,43 @@ exports.constraints = [
 		}
 	},
 	{
-		slug: 'link-constraint-discussion-topic-has-attached-product-improvement',
+		slug: 'link-constraint-brainstorm-topic-has-attached-product-improvement',
 		name: 'has attached',
 		data: {
 			title: 'Product improvement',
-			from: 'discussion-topic',
+			from: 'brainstorm-topic',
 			to: 'product-improvement',
-			inverse: 'link-constraint-product-improvement-is-attached-to-discussion-topic'
+			inverse: 'link-constraint-product-improvement-is-attached-to-brainstorm-topic'
 		}
 	},
 	{
-		slug: 'link-constraint-product-improvement-is-attached-to-discussion-topic',
+		slug: 'link-constraint-product-improvement-is-attached-to-brainstorm-topic',
 		name: 'is attached to',
 		data: {
-			title: 'Discussion topic',
+			title: 'Brainstorm topic',
 			from: 'product-improvement',
-			to: 'discussion-topic',
-			inverse: 'link-constraint-discussion-topic-has-attached-product-improvement'
+			to: 'brainstorm-topic',
+			inverse: 'link-constraint-brainstorm-topic-has-attached-product-improvement'
 		}
 	},
 	{
-		slug: 'link-constraint-discussion-topic-is-source-for-specification',
+		slug: 'link-constraint-brainstorm-topic-is-source-for-specification',
 		name: 'is source for',
 		data: {
 			title: 'Specification',
-			from: 'discussion-topic',
+			from: 'brainstorm-topic',
 			to: 'specification',
-			inverse: 'link-constraint-specification-comes-from-discussion-topic'
+			inverse: 'link-constraint-specification-comes-from-brainstorm-topic'
 		}
 	},
 	{
-		slug: 'link-constraint-specification-comes-from-discussion-topic',
+		slug: 'link-constraint-specification-comes-from-brainstorm-topic',
 		name: 'comes from',
 		data: {
-			title: 'Discussion topic',
+			title: 'Brainstorm topic',
 			from: 'specification',
-			to: 'discussion-topic',
-			inverse: 'link-constraint-discussion-topic-is-source-for-specification'
+			to: 'brainstorm-topic',
+			inverse: 'link-constraint-brainstorm-topic-is-source-for-specification'
 		}
 	},
 	{
@@ -576,26 +576,6 @@ exports.constraints = [
 			from: 'issue',
 			to: 'specification',
 			inverse: 'link-constraint-specification-is-source-for-issue'
-		}
-	},
-	{
-		slug: 'link-constraint-agenda-has-discussion-topic',
-		name: 'has',
-		data: {
-			title: 'Discussion topic',
-			from: 'agenda',
-			to: 'discussion-topic',
-			inverse: 'link-constraint-discussion-topic-appears-in-agenda'
-		}
-	},
-	{
-		slug: 'link-constraint-discussion-topic-appears-in-agenda',
-		name: 'appears in',
-		data: {
-			title: 'Agenda',
-			from: 'discussion-topic',
-			to: 'agenda',
-			inverse: 'link-constraint-agenda-has-discussion-topic'
 		}
 	},
 	{


### PR DESCRIPTION
brainstorm-topic is replacing the discussion-topic card. We have also removed the agenda card are are using brainstorm-call instead