### PR TITLE
Add link constraints for ui themes

### DIFF
--- a/lib/link-constraints.js
+++ b/lib/link-constraints.js
@@ -839,6 +839,26 @@ exports.constraints = [
 		}
 	},
 	{
+		slug: 'link-constraint-user-is-using-ui-theme',
+		name: 'is using',
+		data: {
+			title: 'UI Theme',
+			from: 'user',
+			to: 'ui-theme',
+			inverse: 'link-constraint-ui-theme-is-used-by-user'
+		}
+	},
+	{
+		slug: 'link-constraint-ui-theme-is-used-by-user',
+		name: 'is used by',
+		data: {
+			title: 'User',
+			from: 'ui-theme',
+			to: 'user',
+			inverse: 'link-constraint-user-is-using-ui-theme'
+		}
+	},
+	{
 		slug: 'link-constraint-pattern-is-attached-to-user-feedback',
 		name: 'is attached to',
 		data: {


### PR DESCRIPTION
Used by users

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This is a necessary pre-requisite for adding support for users selecting a UI theme with which to display Jellyfish.