### PR TITLE
Ensure stream attempts to reconnect indefinitely when the connection has dropped

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -70,6 +70,8 @@ class JellyfishStreamManager {
 
 		// Create a new socket.io client connected to the API
 		const socket = io(url, {
+			reconnection: true,
+			reconnectionAttempts: Infinity,
 			transports: [ 'websocket', 'polling' ]
 		})
 


### PR DESCRIPTION
At the moment, when the connection is dropped we only attempt to reconnect a couple of times. If the socket doesn't come available in time we never reconnect and thus stop getting streaming updates on a page.

This can be reproduced locally through the following steps:

1. Setup Jellyfish locally with this version of the sdk
2. Login to Jellyfish and navigate to the inbox
3. Open a private window and log into Jellyfish with another account. Ping the user whose inbox you have open
4. Ping should appear in first browser window
5. Now shutdown the server, wait a minute, and start it up again
6. Pin the same user from your private window
7. Before this change, the new message would not appear in the inbox. After this change, it does
