### PR TITLE
Update link creation to include to and from card slug

### DIFF
--- a/lib/card.js
+++ b/lib/card.js
@@ -591,11 +591,13 @@ class CardSdk {
 						inverseName: inverseOption.name,
 						from: {
 							id: fromCard.id,
-							type: fromCard.type
+							type: fromCard.type,
+							slug: fromCard.slug
 						},
 						to: {
 							id: toCard.id,
-							type: toCard.type
+							type: toCard.type,
+							slug: toCard.slug
 						}
 					}
 				}


### PR DESCRIPTION
This PR is part of the work to include links in the Timeline of the card. In order to do this, we are going to update the `loadChannelData` action in the ui to include queries for link cards that either have the to or the from id set to the id of the card we are rendering (see this PR: https://github.com/product-os/jellyfish/pull/5113/files)

We are adding the slug to the links so that we can show the user a human-readable id to the card that has been linked to instead of just the id. For example, if my user card was linked on an organisation, we could have a message like (Org has member `user-ljewalsh`)

Change-type: patch
Signed-off-by: Lucy-Jane Walsh <lucy-jane@balena.io>