### PR TITLE
Require Node v14

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,0 +1,7 @@
+npm:
+  platforms:
+    - name: linux
+      os: alpine
+      architecture: x86_64
+      node_versions:
+        - "14"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "https://github.com/product-os/jellyfish-client-sdk.git"
   },
+  "engines": {
+    "node": ">=14.2.0"
+  },
   "description": "HTTP client SDK for Jellyfish",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Require Node v14 as that is what we use during CI and in production.
Setting the minimum at v14.2.0 as that is what balenaCI uses when running v14 tests.

Also only run Node v14 tests in CI, requiring v14 causes lesser version tests to fail.