### PR TITLE
Check for reverse links when unlinking cards

### DIFF
--- a/lib/card.js
+++ b/lib/card.js
@@ -15,6 +15,9 @@ const {
 	v4: uuid
 } = require('uuid')
 const isUUID = require('isuuid')
+const {
+	getReverseConstraint
+} = require('./link-constraints')
 
 const checkLinksExist = async (sdk, verb, fromCard, toCard = null) => {
 	const query = {
@@ -52,26 +55,16 @@ const checkLinksExist = async (sdk, verb, fromCard, toCard = null) => {
 	return true
 }
 
-const getLinkQuery = (verb, fromCard, toCard = null) => {
-	const query = {
-		type: 'object',
-		required: [ 'name', 'type', 'active', 'data' ],
+const getLinkQueryOption = (verb, fromCardId, toCardId) => {
+	return {
 		properties: {
 			name: {
 				type: 'string',
 				const: verb
 			},
-			type: {
-				type: 'string',
-				const: 'link@1.0.0'
-			},
-			active: {
-				type: 'boolean',
-				const: true
-			},
 			data: {
 				type: 'object',
-				required: [ 'from' ],
+				required: [ 'from', 'to' ],
 				properties: {
 					from: {
 						type: 'object',
@@ -79,31 +72,51 @@ const getLinkQuery = (verb, fromCard, toCard = null) => {
 						properties: {
 							id: {
 								type: 'string',
-								const: fromCard.id
+								const: fromCardId
+							}
+						}
+					},
+					to: {
+						type: 'object',
+						required: [ 'id' ],
+						properties: {
+							id: {
+								type: 'string',
+								const: toCardId
 							}
 						}
 					}
 				}
 			}
+		}
+	}
+}
+
+const getLinkQuery = (verb, fromCard, toCard) => {
+	const reverseVerb = getReverseConstraint(
+		fromCard.type.split('@')[0],
+		toCard.type.split('@')[0],
+		verb).name
+
+	return {
+		type: 'object',
+		required: [ 'name', 'type', 'active', 'data' ],
+		anyOf: [
+			getLinkQueryOption(verb, fromCard.id, toCard.id),
+			getLinkQueryOption(reverseVerb, toCard.id, fromCard.id)
+		],
+		properties: {
+			type: {
+				type: 'string',
+				const: 'link@1.0.0'
+			},
+			active: {
+				type: 'boolean',
+				const: true
+			}
 		},
 		additionalProperties: true
 	}
-
-	if (toCard) {
-		query.properties.data.required.push('to')
-		query.properties.data.properties.to = {
-			type: 'object',
-			required: [ 'id' ],
-			properties: {
-				id: {
-					type: 'string',
-					const: toCard.id
-				}
-			}
-		}
-	}
-
-	return query
 }
 
 exports.isMentionedInMessage = (card, userSlug, userGroups = []) => {

--- a/lib/card.spec.js
+++ b/lib/card.spec.js
@@ -18,6 +18,8 @@ const {
 	CardSdk
 } = require('./card')
 
+const sandbox = sinon.createSandbox()
+
 const nock = require('nock')
 
 const API_URL = 'https://test.ly.fish'
@@ -92,6 +94,10 @@ const testMarkAsUnreadMention = async (test, message, userSlug, userGroups, expe
 		test.true(sdk.card.update.notCalled)
 	}
 }
+
+ava.afterEach(() => {
+	sandbox.restore()
+})
 
 ava.serial.before(async (test) => {
 	test.context.sdk = getSdk({
@@ -453,4 +459,108 @@ ava('isMentionedInMessage matches markers with non-alphanumeric characters', asy
 	test.true(isMentionedInMessage(Object.assign(makeMessageCard('Hello'), {
 		markers: [ 'user-test_user' ]
 	}), 'user-test_user'))
+})
+
+ava('unlink will unlink all links between two cards with the specified verb', async (test) => {
+	// Two links between the same two cards, both with the same name
+	const linkCards = [
+		{
+			id: 'link1',
+			type: 'link@1.0.0',
+			name: 'is attached to',
+			data: {
+				from: 'opportunity1',
+				to: 'account1'
+			}
+		},
+		{
+			id: 'link2',
+			type: 'link@1.0.0',
+			name: 'is attached to',
+			data: {
+				from: 'opportunity1',
+				to: 'account1'
+			}
+		}
+	]
+
+	const account1 = {
+		id: 'account1',
+		type: 'account@1.0.0'
+	}
+
+	const opportunity1 = {
+		id: 'opportunity1',
+		type: 'opportunity@1.0.0'
+	}
+
+	const sdk = {
+		action: sandbox.stub().resolves(null),
+		query: sandbox.stub().resolves(linkCards)
+	}
+
+	const cardSdk = new CardSdk(sdk)
+
+	await cardSdk.unlink(account1, opportunity1, 'has attached')
+
+	// The SDK is used to delete BOTH existing links
+	test.is(sdk.action.callCount, linkCards.length)
+	test.deepEqual(sdk.action.getCall(0).firstArg, {
+		action: 'action-delete-card@1.0.0',
+		card: linkCards[0].id,
+		type: linkCards[0].type
+	})
+	test.deepEqual(sdk.action.getCall(1).firstArg, {
+		action: 'action-delete-card@1.0.0',
+		card: linkCards[1].id,
+		type: linkCards[1].type
+	})
+})
+
+ava('unlink will unlink \'reverse\' links between two cards with the specified verb', async (test) => {
+	const linkCards = [
+		{
+			id: 'link1',
+			type: 'link@1.0.0',
+			name: 'is attached to',
+			data: {
+				from: 'opportunity1',
+				to: 'account1'
+			}
+		}
+	]
+
+	const account1 = {
+		id: 'account1',
+		type: 'account@1.0.0'
+	}
+
+	const opportunity1 = {
+		id: 'opportunity1',
+		type: 'opportunity@1.0.0'
+	}
+
+	const sdk = {
+		action: sandbox.stub().resolves(null),
+		query: sandbox.stub().resolves(linkCards)
+	}
+
+	const cardSdk = new CardSdk(sdk)
+
+	await cardSdk.unlink(account1, opportunity1, 'has attached')
+
+	test.is(sdk.action.callCount, linkCards.length)
+
+	test.true(sdk.query.calledOnce)
+	const query = sdk.query.getCall(0).firstArg
+
+	// The query should contain options for both the 'forward' and 'reverse'
+	// links between these two cards
+	const [ firstLinkOption, secondLinkOption ] = query.anyOf
+	test.is(firstLinkOption.properties.name.const, 'has attached')
+	test.is(firstLinkOption.properties.data.properties.from.properties.id.const, 'account1')
+	test.is(firstLinkOption.properties.data.properties.to.properties.id.const, 'opportunity1')
+	test.is(secondLinkOption.properties.name.const, 'is attached to')
+	test.is(secondLinkOption.properties.data.properties.from.properties.id.const, 'opportunity1')
+	test.is(secondLinkOption.properties.data.properties.to.properties.id.const, 'account1')
 })

--- a/lib/link-constraints.js
+++ b/lib/link-constraints.js
@@ -1079,3 +1079,24 @@ exports.constraints = [
 		}
 	}
 ]
+
+/**
+ * Get the reverse link constraint for a given set of constraints
+ *
+ * @param {String} fromType - the type of card the link is from
+ * @param {String} toType - the type of card the link is to
+ * @param {String} name - the link verb
+ * @returns {Object} - the reverse link if found; otherwise undefined
+ */
+exports.getReverseConstraint = (fromType, toType, name) => {
+	const constraint = _.find(exports.constraints, {
+		name,
+		data: {
+			from: fromType.split('@')[0],
+			to: toType.split('@')[0]
+		}
+	})
+	return constraint && _.find(exports.constraints, {
+		slug: constraint.data.inverse
+	})
+}

--- a/lib/link-constraints.spec.js
+++ b/lib/link-constraints.spec.js
@@ -7,6 +7,7 @@
 const ava = require('ava')
 const _ = require('lodash')
 const {
+	getReverseConstraint,
 	supportsLink,
 	constraints
 } = require('./link-constraints')
@@ -32,4 +33,17 @@ ava('supportsLink returns true for support-thread and the \'is owned by\' link n
 
 ava('supportsLink returns false for support-issue and the \'is owned by\' link name', (test) => {
 	test.false(supportsLink('support-issue', 'is owned by'))
+})
+
+ava('getReverseConstraint returns the reverse constraint if it exists', (test) => {
+	const reverseConstraint = getReverseConstraint('opportunity@1.0.0', 'account@1.0.0', 'is attached to')
+	test.is(reverseConstraint.name, 'has attached')
+	test.is(reverseConstraint.data.from, 'account')
+	test.is(reverseConstraint.data.to, 'opportunity')
+})
+
+ava('getReverseConstraint returns undefined if constraint is not found', (test) => {
+	const reverseConstraint = getReverseConstraint('foo@1.0.0', 'account@1.0.0', 'is attached to')
+	// eslint-disable-next-line no-undefined
+	test.is(reverseConstraint, undefined)
 })


### PR DESCRIPTION
For example, assume a link exists ('card-1' 'has attached' 'card2'). When you use the `unlink` method to unlink 'card2' from 'card1' using the verb 'is attached to', it should check for and remove the existing reverse link.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

This PR fixes an existing issue:

We define links with a particular 'direction' specified. For example `'account1'` `'has attached'` `'opportunity1'`. 
* This (pseudocode) works: `unlink('account1', 'opportunity1', 'has attached')`
* But this does _not_ work: `unlink('opportunity1', 'account1', 'is attached to')`
