### PR TITLE
Add link between patterns and threads

### DIFF
--- a/lib/link-constraints.js
+++ b/lib/link-constraints.js
@@ -189,6 +189,26 @@ exports.constraints = [
 		}
 	},
 	{
+		slug: 'link-constraint-pattern-is-attached-to-thread',
+		name: 'is attached to',
+		data: {
+			title: 'Thread',
+			from: 'pattern',
+			to: 'thread',
+			inverse: 'link-constraint-thread-has-attached-pattern'
+		}
+	},
+	{
+		slug: 'link-constraint-thread-has-attached-pattern',
+		name: 'has attached',
+		data: {
+			title: 'Pattern',
+			from: 'thread',
+			to: 'pattern',
+			inverse: 'link-constraint-pattern-is-attached-to-thread'
+		}
+	},
+	{
 		slug: 'link-constraint-product-improvement-is-attached-to-pattern',
 		name: 'is attached to',
 		data: {


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This will let people create new patterns linked to a (e.g. repository) thread that started the discussion.

See [this Flowdock chat](https://www.flowdock.com/app/rulemotion/p-cyclops/threads/wFOwSG5LkSJy01UdYie1ufLhJYr)