### PR TITLE
Improve performance of query for existing links

### DIFF
--- a/lib/card.js
+++ b/lib/card.js
@@ -58,6 +58,7 @@ const checkLinksExist = async (sdk, verb, fromCard, toCard = null) => {
 const getLinkQueryOption = (verb, fromCardId, toCardId) => {
 	return {
 		properties: {
+			required: [ 'name', 'data' ],
 			name: {
 				type: 'string',
 				const: verb
@@ -100,7 +101,7 @@ const getLinkQuery = (verb, fromCard, toCard) => {
 
 	return {
 		type: 'object',
-		required: [ 'name', 'type', 'active', 'data' ],
+		required: [ 'type', 'active' ],
 		anyOf: [
 			getLinkQueryOption(verb, fromCard.id, toCard.id),
 			getLinkQueryOption(reverseVerb, toCard.id, fromCard.id)


### PR DESCRIPTION
Add a limit to the query for existing links

There should never be more than one link between two cards for a particular verb.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Fix query for getting existing links

Each item in the `anyOf` must define all it's `required` fields itself (rather than relying on the top-level `required`)

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Relates to https://github.com/product-os/jellyfish/issues/5596