### PR TITLE
Fix JSON schema for link query option

### DIFF
--- a/lib/card.js
+++ b/lib/card.js
@@ -57,8 +57,9 @@ const checkLinksExist = async (sdk, verb, fromCard, toCard = null) => {
 
 const getLinkQueryOption = (verb, fromCardId, toCardId) => {
 	return {
+		type: 'object',
+		required: [ 'name', 'data' ],
 		properties: {
-			required: [ 'name', 'data' ],
 			name: {
 				type: 'string',
 				const: verb


### PR DESCRIPTION
'required' field was incorrectly placed underneath 'properties'.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>
***


![](https://media2.giphy.com/media/BxWTWalKTUAdq/giphy.gif?cid=5a38a5a2uq0794kbx84omvupcn16unghe6i98y8an64hvdbh&rid=giphy.gif)
