### PR TITLE
Standardise on is-uuid

### DIFF
--- a/lib/card.js
+++ b/lib/card.js
@@ -14,7 +14,9 @@ const _ = require('lodash')
 const {
 	v4: uuid
 } = require('uuid')
-const isUUID = require('isuuid')
+const {
+	v4: isUUID
+} = require('is-uuid')
 const {
 	getReverseConstraint
 } = require('./link-constraints')

--- a/package-lock.json
+++ b/package-lock.json
@@ -2432,6 +2432,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-uuid": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-uuid/-/is-uuid-1.0.2.tgz",
+      "integrity": "sha1-rRiY3fFUlHwlyOVJZvSGBOnK7MQ="
+    },
     "is-yarn-global": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
@@ -2448,11 +2453,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isuuid": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/isuuid/-/isuuid-0.1.0.tgz",
-      "integrity": "sha1-UIEJrBQNbeQ7P4RlBs22Zd0+hzM="
     },
     "js-string-escape": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "common-tags": "^1.8.0",
     "deep-copy": "^1.4.2",
     "fast-json-patch": "^3.0.0-1",
-    "isuuid": "^0.1.0",
+    "is-uuid": "^1.0.2",
     "lodash": "^4.17.21",
     "socket.io-client": "^2.4.0",
     "uuid": "^8.3.2"


### PR DESCRIPTION
Other Jellyfish packages use is-uuid. Also it explicitly refers to v4 which should be safer/more accurate.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>