### PR TITLE
minor: Adding pattern-to-pattern relationship to link-contraints.ts

### DIFF
--- a/lib/link-constraints.ts
+++ b/lib/link-constraints.ts
@@ -302,6 +302,16 @@ export const constraints: LinkConstraint[] = [
 		},
 	},
 	{
+		slug: 'link-constraint-pattern-relates-to-pattern',
+		name: 'relates to',
+		data: {
+			title: 'Related pattern',
+			from: 'pattern',
+			to: 'pattern',
+			inverse: 'link-constraint-pattern-relates-to-pattern',
+		},
+	},
+	{
 		slug: 'link-constraint-product-improvement-is-owned-by-user',
 		name: 'is owned by',
 		data: {


### PR DESCRIPTION
Adding a pattern-to-pattern relationship to allow creating groups of patterns and linking related patterns.
Normally you would have a separate inverse, but because this is self similar its the same