### PR TITLE
Return a Cursor object from sdk.stream()

### DIFF
--- a/lib/cursor.spec.ts
+++ b/lib/cursor.spec.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import { JSONSchema } from '@balena/jellyfish-types';
+import sinon from 'sinon';
+import EventEmitter from 'events';
+import { getSdk } from '.';
+import { JellyfishCursor } from './cursor';
+
+const API_URL = 'https://test.ly.fish';
+
+const sandbox = sinon.createSandbox();
+
+const sdk = getSdk({
+	apiPrefix: 'api/v2',
+	apiUrl: API_URL,
+});
+sdk.globalQueryMask = {
+	type: 'object',
+	required: ['loop'],
+	properties: {
+		loop: {
+			const: 'l/product-os',
+		},
+	},
+};
+
+const makeSocketStub = () => {
+	const socket = new EventEmitter();
+	socket.on('queryDataset', (event) => {
+		socket.emit('dataset', {
+			data: {
+				id: event.data.id,
+				cards: [],
+			},
+		});
+	});
+
+	return socket;
+};
+
+const schema: JSONSchema = {
+	type: 'object',
+};
+
+const optionsWithoutLimit = {
+	skip: 0,
+};
+
+const optionsWithLimit = {
+	...optionsWithoutLimit,
+	limit: 10,
+};
+
+describe('JellyfishCursor', () => {
+	afterEach(() => {
+		sandbox.reset();
+	});
+
+	describe('query()', () => {
+		it('applies the global query mask', async () => {
+			const socketStub = makeSocketStub();
+			const spy = sinon.spy(socketStub, 'emit');
+			const cursor = new JellyfishCursor(
+				sdk,
+				socketStub as any,
+				schema,
+				optionsWithLimit,
+			);
+			await cursor.query();
+			const callArgs = spy.getCall(0).args;
+			expect(callArgs).toEqual([
+				'queryDataset',
+				{
+					data: {
+						id: callArgs[1].data.id,
+						schema,
+						options: {
+							...optionsWithLimit,
+							mask: sdk.globalQueryMask,
+						},
+					},
+				},
+			]);
+		});
+	});
+
+	describe('nextPage()', () => {
+		it('increases options.skip by options.limit when set', async () => {
+			const socketStub = makeSocketStub();
+			const spy = sinon.spy(socketStub, 'emit');
+			const cursor = new JellyfishCursor(
+				sdk,
+				socketStub as any,
+				schema,
+				optionsWithLimit,
+			);
+			await cursor.nextPage();
+			const callArgs = spy.getCall(0).args;
+			expect(callArgs).toEqual([
+				'queryDataset',
+				{
+					data: {
+						id: callArgs[1].data.id,
+						schema,
+						options: {
+							...optionsWithLimit,
+							limit: optionsWithLimit.limit + 1,
+							skip: 30,
+							mask: sdk.globalQueryMask,
+						},
+					},
+				},
+			]);
+		});
+	});
+
+	describe('prevPage()', () => {
+		it('decreases options.skip by options.limit', async () => {
+			const socketStub = makeSocketStub();
+			const spy = sinon.spy(socketStub, 'emit');
+			const cursor = new JellyfishCursor(
+				sdk,
+				socketStub as any,
+				schema,
+				optionsWithLimit,
+			);
+			await cursor.nextPage();
+			await cursor.prevPage();
+			const callArgs = spy.getCall(1).args;
+			expect(callArgs).toEqual([
+				'queryDataset',
+				{
+					data: {
+						id: callArgs[1].data.id,
+						schema,
+						options: {
+							...optionsWithLimit,
+							skip: 10,
+							mask: sdk.globalQueryMask,
+						},
+					},
+				},
+			]);
+		});
+
+		it.only('uses a default limit if options.limit is not set', async () => {
+			const socketStub = makeSocketStub();
+			const spy = sinon.spy(socketStub, 'emit');
+			const cursor = new JellyfishCursor(
+				sdk,
+				socketStub as any,
+				schema,
+				optionsWithoutLimit,
+			);
+			await cursor.nextPage();
+			await cursor.prevPage();
+			const callArgs = spy.getCall(2).args;
+			expect(callArgs).toEqual([
+				'queryDataset',
+				{
+					data: {
+						id: callArgs[1].data.id,
+						schema,
+						options: {
+							...optionsWithoutLimit,
+							limit: 21,
+							skip: 0,
+							mask: sdk.globalQueryMask,
+						},
+					},
+				},
+			]);
+		});
+	});
+});

--- a/lib/cursor.ts
+++ b/lib/cursor.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+import cloneDeep from 'lodash/cloneDeep';
+import { JSONSchema } from '@balena/jellyfish-types';
+import { v4 as uuid } from 'uuid';
+import type { ExtendedSocket } from './types';
+import type { JellyfishSDK } from '.';
+import { Contract, QueryOptions } from '@balena/jellyfish-types/build/core';
+
+export type CursorEventName =
+	| 'update'
+	| 'ready'
+	| 'error'
+	| 'typing'
+	| 'streamError';
+
+export class JellyfishCursor<T extends Contract = Contract> {
+	private options: QueryOptions & { limit: number };
+	private schema: JSONSchema;
+	private hasmore = true;
+	private page = 1;
+
+	constructor(
+		private sdk: JellyfishSDK,
+		public socket: ExtendedSocket,
+		schema: JSONSchema,
+		options: QueryOptions,
+	) {
+		this.schema = schema;
+		this.options = {
+			limit: 20,
+			...this.sdk.applyGlobalQueryMask(options),
+		};
+	}
+
+	hasNextPage(): boolean {
+		return this.hasmore;
+	}
+
+	getCurrenPage(): number {
+		return this.page;
+	}
+
+	async query(): Promise<T[]> {
+		const queryId = uuid();
+		return new Promise((resolve) => {
+			const handler = ({ data }) => {
+				if (data.id === queryId) {
+					resolve(data.cards);
+					this.socket.off('dataset', handler);
+				}
+			};
+			this.socket.on('dataset', handler);
+
+			this.socket.emit('queryDataset', {
+				data: {
+					id: queryId,
+					schema: this.schema,
+					options: {
+						...this.options,
+						// Request 1 item more than the limit, so we can detect if another page of results is available.
+						limit: this.options.limit + 1,
+					},
+				},
+			});
+		});
+	}
+
+	async nextPage(): Promise<T[]> {
+		const newOptions = cloneDeep(this.options);
+
+		this.page += 1;
+
+		this.options = {
+			...newOptions,
+			limit: this.options.limit,
+			skip: (newOptions.skip || 0) + this.options.limit,
+		};
+
+		const results = await this.query();
+
+		// If an extra item was retrieved, another page is available
+		this.hasmore = results.length > this.options.limit;
+
+		return results;
+	}
+
+	async prevPage(): Promise<T[]> {
+		if (this.page === 1) {
+			return [];
+		}
+		this.page -= 1;
+		const newOptions = cloneDeep(this.options);
+
+		this.options = {
+			...newOptions,
+			skip: Math.max(0, (newOptions.skip || 0) - this.options.limit),
+		};
+
+		return this.query();
+	}
+
+	on(event: CursorEventName, fn: () => void): JellyfishCursor {
+		this.socket.on(event, fn);
+		return this;
+	}
+
+	onUpdate(fn: () => void): JellyfishCursor {
+		this.socket.on('update', fn);
+		return this;
+	}
+
+	close(): JellyfishCursor {
+		this.socket.close();
+		return this;
+	}
+}

--- a/lib/stream.ts
+++ b/lib/stream.ts
@@ -6,6 +6,7 @@ import { v4 as uuid } from 'uuid';
 import type { JSONSchema } from '@balena/jellyfish-types';
 import { JellyfishSDK, applyMask } from '.';
 import type { ExtendedSocket, SdkQueryOptions } from './types';
+import { JellyfishCursor } from './cursor';
 
 /**
  * @class JellyfishStreamManager
@@ -36,8 +37,8 @@ export class JellyfishStreamManager {
 	 * Returns a socket object that emits response data for the given query
 	 * @param {SdkQueryOptions} options - Extra query options to use
 	 *
-	 * @fulfil {JellyfishStream} An instantiated JellyfishStream
-	 * @returns {Promise}
+	 * @returns {Promise<Cursor>} An instantiated Cursor object that can be used
+	 * to interact with the underlying stream
 	 *
 	 * @example
 	 * const schema = {
@@ -49,17 +50,17 @@ export class JellyfishStreamManager {
 	 * 	}
 	 * };
 	 *
-	 * const stream = jellyfishStreamManager.stream(schema)
+	 * const cursor = jellyfishStreamManager.stream(schema)
 	 *
-	 * stream.on('update', (data) => {
+	 * cursor.on('update', (data) => {
 	 * 	console.log(data);
 	 * })
 	 *
-	 * stream.on('streamError', (error) => {
+	 * cursor.on('streamError', (error) => {
 	 * 	console.error(error);
 	 * })
 	 */
-	stream(query: JSONSchema, options: SdkQueryOptions): ExtendedSocket {
+	stream(query: JSONSchema, options: SdkQueryOptions): JellyfishCursor {
 		const url = this.sdk.getApiUrl();
 		if (!url) {
 			throw new Error(
@@ -127,7 +128,7 @@ export class JellyfishStreamManager {
 			});
 		};
 
-		return socket;
+		return new JellyfishCursor(this.sdk, socket, query, options);
 	}
 
 	/**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -36,3 +36,9 @@ export interface QueryOptions
 export interface SdkQueryOptions extends QueryOptions {
 	ignoreMask?: boolean;
 }
+
+export interface GlobalQueryOptions {
+	ignoreGlobalQueryMask?: boolean;
+}
+
+export interface QueryCallOptions extends GlobalQueryOptions, QueryOptions {}


### PR DESCRIPTION
The cursor object wraps the underlying socket and encapsulates all interaction with it.

This commit also adds support for a global query mask. The global query mask is a schema that will be applied to all subsequent queries. The global query mask can be 'cleared' (unset) by setting it to `undefined`.

You can also manually ignore the global query schema when calling `query()` or `stream()` by passing `ignoreGlobalQueryMask: true` in the options argument.

Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Probably to be replaced by https://github.com/product-os/jellyfish-client-sdk/pull/427