### PR TITLE
Remove link constraints relating to loops

### DIFF
--- a/lib/link-constraints.ts
+++ b/lib/link-constraints.ts
@@ -1016,46 +1016,6 @@ export const constraints: LinkConstraint[] = [
 		},
 	},
 	{
-		slug: 'link-constraint-brainstorm-topic-is-owned-by-loop',
-		name: 'is owned by',
-		data: {
-			title: 'Loop',
-			from: 'brainstorm-topic',
-			to: 'loop',
-			inverse: 'link-constraint-loop-owns-brainstorm-topic',
-		},
-	},
-	{
-		slug: 'link-constraint-loop-owns-brainstorm-topic',
-		name: 'owns',
-		data: {
-			title: 'Brainstorm topic',
-			from: 'loop',
-			to: 'brainstorm-topic',
-			inverse: 'link-constraint-brainstorm-topic-is-owned-by-loop',
-		},
-	},
-	{
-		slug: 'link-constraint-brainstorm-call-is-owned-by-loop',
-		name: 'is owned by',
-		data: {
-			title: 'Loop',
-			from: 'brainstorm-call',
-			to: 'loop',
-			inverse: 'link-constraint-loop-owns-brainstorm-call',
-		},
-	},
-	{
-		slug: 'link-constraint-loop-owns-brainstorm-call',
-		name: 'owns',
-		data: {
-			title: 'Brainstorm call',
-			from: 'loop',
-			to: 'brainstorm-call',
-			inverse: 'link-constraint-brainstorm-call-is-owned-by-loop',
-		},
-	},
-	{
 		slug: 'link-constraint-user-is-using-ui-theme',
 		name: 'is using',
 		data: {
@@ -1213,46 +1173,6 @@ export const constraints: LinkConstraint[] = [
 			from: 'rating',
 			to: 'user',
 			inverse: 'link-constraint-user-owns-rating',
-		},
-	},
-	{
-		slug: 'link-constraint-loop-owns-product-improvement',
-		name: 'owns',
-		data: {
-			title: 'Improvement',
-			from: 'loop',
-			to: 'product-improvement',
-			inverse: 'link-constraint-product-improvement-is-owned-by-loop',
-		},
-	},
-	{
-		slug: 'link-constraint-product-improvement-is-owned-by-loop',
-		name: 'is owned by',
-		data: {
-			title: 'Loop',
-			from: 'product-improvement',
-			to: 'loop',
-			inverse: 'link-constraint-loop-owns-product-improvement',
-		},
-	},
-	{
-		slug: 'link-constraint-loop-owns-pattern',
-		name: 'owns',
-		data: {
-			title: 'Pattern',
-			from: 'loop',
-			to: 'pattern',
-			inverse: 'link-constraint-pattern-is-owned-by-loop',
-		},
-	},
-	{
-		slug: 'link-constraint-pattern-is-owned-by-loop',
-		name: 'is owned by',
-		data: {
-			title: 'Loop',
-			from: 'pattern',
-			to: 'loop',
-			inverse: 'link-constraint-loop-owns-pattern',
 		},
 	},
 	{


### PR DESCRIPTION
Loops will not be associated using links but with a top-level 'loop' field on each contract. This commit removes some link constraints that were recently added but are no longer appropriate. Although this constitutes a major bump there should be no problem with removing these link constraints as they were not being used yet.

Note - there are still link-constraints defined between loops & contract-repository and loops & transformers. These will be removed at a later time once the code that relies on these links has been updated.

Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>