### PR TITLE
Add more links between users and product improvements

### DIFF
--- a/lib/link-constraints.ts
+++ b/lib/link-constraints.ts
@@ -322,6 +322,66 @@ export const constraints: LinkConstraint[] = [
 		},
 	},
 	{
+		slug: 'link-constraint-product-improvement-has-dedicated-user',
+		name: 'has dedicated user',
+		data: {
+			title: 'Dedicated user',
+			from: 'product-improvement',
+			to: 'user',
+			inverse: 'link-constraint-user-is-dedicated-to-product-improvement',
+		},
+	},
+	{
+		slug: 'link-constraint-user-is-dedicated-to-product-improvement',
+		name: 'is dedicated to',
+		data: {
+			title: 'Product improvement',
+			from: 'user',
+			to: 'product-improvement',
+			inverse: 'link-constraint-product-improvement-has-dedicated-user',
+		},
+	},
+	{
+		slug: 'link-constraint-product-improvement-is-contributed-to-by-user',
+		name: 'is contributed to by',
+		data: {
+			title: 'Contributor',
+			from: 'product-improvement',
+			to: 'user',
+			inverse: 'link-constraint-user-contributes-to-product-improvement',
+		},
+	},
+	{
+		slug: 'link-constraint-user-contributes-to-product-improvement',
+		name: 'contributes to',
+		data: {
+			title: 'Product improvement',
+			from: 'user',
+			to: 'product-improvement',
+			inverse: 'link-constraint-product-improvement-is-contributed-to-by-user',
+		},
+	},
+	{
+		slug: 'link-constraint-product-improvement-is-guided-by-user',
+		name: 'is guided by',
+		data: {
+			title: 'Guide',
+			from: 'product-improvement',
+			to: 'user',
+			inverse: 'link-constraint-user-guides-product-improvement',
+		},
+	},
+	{
+		slug: 'link-constraint-user-guides-product-improvement',
+		name: 'guides',
+		data: {
+			title: 'Product improvement',
+			from: 'user',
+			to: 'product-improvement',
+			inverse: 'link-constraint-product-improvement-is-guided-by-user',
+		},
+	},
+	{
 		slug: 'link-constraint-support-issue-is-attached-to-issue',
 		name: 'support issue is attached to issue',
 		data: {


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Relates to: [Jellyfish Loop MVP 'Pilot Rope'](https://jel.ly.fish/c328c216-a90c-4636-98f6-cd04040ece23?event=2731239c-e2b9-4562-b7d3-4f4e83e82a57)

This PR adds the following link constraints:
```
<user> is dedicated to <improvement>
<improvement> has dedicated user <user>

<user> contributes to <improvement>
<improvement> is contributed to by <user>

<user> guides <improvement>
<improvement> is guided by <user>
```
