### PR TITLE
Add support for sdk.globalQueryMask

### DIFF
--- a/lib/card.ts
+++ b/lib/card.ts
@@ -62,6 +62,7 @@ const checkLinksExist = async (
 
 	const result = await sdk.query(query, {
 		limit: 1,
+		ignoreMask: true,
 	});
 
 	if (!result.length) {
@@ -271,7 +272,10 @@ export class CardSdk {
 	 */
 	async getWithTimeline<TContract extends core.Contract = core.Contract>(
 		idOrSlug: string,
-		options: { schema?: JSONSchema; queryOptions?: QueryOptions } = {},
+		options: {
+			schema?: JSONSchema;
+			queryOptions?: Omit<QueryOptions, 'mask'>;
+		} = {},
 	): Promise<TContract | null> {
 		const schema: JSONSchema = isUUID(idOrSlug)
 			? {
@@ -478,7 +482,9 @@ export class CardSdk {
 			additionalProperties: true,
 		};
 
-		return this.sdk.query(schema);
+		return this.sdk.query(schema, {
+			ignoreMask: true,
+		});
 	}
 
 	/**
@@ -736,6 +742,7 @@ export class CardSdk {
 		return this.sdk
 			.query(getLinkQuery(verb, fromCard, toCard), {
 				limit: 1,
+				ignoreMask: true,
 			})
 			.then((linkCards) => {
 				// Then remove the link cards

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,4 @@
-import type { core } from '@balena/jellyfish-types';
+import type { core, JSONSchema } from '@balena/jellyfish-types';
 
 export type ExtendedSocket = SocketIOClient.Socket & {
 	type?: ((user: core.Contract, card: core.Contract) => void) | undefined;
@@ -27,9 +27,11 @@ export interface Message extends core.Contract {
 	};
 }
 
-export interface QueryOptions {
-	skip?: number;
-	limit?: number;
-	sortBy?: string;
-	links?: Omit<QueryOptions, 'links'>;
+export interface QueryOptions
+	extends Omit<core.QueryOptions, 'connection' | 'profile'> {
+	mask?: JSONSchema;
+}
+
+export interface SdkQueryOptions extends QueryOptions {
+	ignoreMask?: boolean;
 }


### PR DESCRIPTION
The global mask is a schema that will be applied to all subsequent queries. The global mask can be 'cleared' (unset) by setting it to `null`.

You can also manually ignore the global query schema when calling `query()`, `view()` or `stream()` by passing `ignoreMask: true` in the `options` argument.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Relates to https://github.com/product-os/jellyfish-core/pull/824