### PR TITLE
Make stream creation sync

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -850,10 +850,7 @@ export class JellyfishSDK {
 	 * 	console.error(error);
 	 * })
 	 */
-	stream(
-		query: JSONSchema,
-		options: SdkQueryOptions = {},
-	): Promise<ExtendedSocket> {
+	stream(query: JSONSchema, options: SdkQueryOptions = {}): ExtendedSocket {
 		return this.streamManager.stream(query, options);
 	}
 }

--- a/lib/stream.ts
+++ b/lib/stream.ts
@@ -65,10 +65,7 @@ export class JellyfishStreamManager {
 	 * 	console.error(error);
 	 * })
 	 */
-	async stream(
-		query: JSONSchema,
-		options: SdkQueryOptions,
-	): Promise<ExtendedSocket> {
+	stream(query: JSONSchema, options: SdkQueryOptions): ExtendedSocket {
 		const url = this.sdk.getApiUrl();
 		if (!url) {
 			throw new Error(
@@ -97,13 +94,6 @@ export class JellyfishStreamManager {
 						query: omit(query, '$id'),
 						options: applyMask(options, this.sdk.globalQueryMask),
 					},
-				});
-			});
-
-			// Wait for the API stream to become ready before proceeeding
-			await new Promise<void>((resolve) => {
-				socket.on('ready', () => {
-					resolve();
 				});
 			});
 		}

--- a/lib/stream.ts
+++ b/lib/stream.ts
@@ -7,7 +7,7 @@
 import omit from 'lodash/omit';
 import set from 'lodash/set';
 import forEach from 'lodash/forEach';
-import io from 'socket.io-client';
+import io, { Socket } from 'socket.io-client';
 import { v4 as uuid } from 'uuid';
 import type { JSONSchema } from '@balena/jellyfish-types';
 import { JellyfishSDK, applyMask } from '.';
@@ -20,7 +20,7 @@ import type { ExtendedSocket, SdkQueryOptions } from './types';
  * connection the API
  */
 export class JellyfishStreamManager {
-	private activeSockets: { [key: string]: SocketIOClient.Socket };
+	private activeSockets: { [key: string]: Socket };
 
 	/**
 	 * @summary Create a JellyfishStreamManager

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,6 +1,7 @@
+import type { Socket } from 'socket.io-client';
 import type { core, JSONSchema } from '@balena/jellyfish-types';
 
-export type ExtendedSocket = SocketIOClient.Socket & {
+export type ExtendedSocket = typeof Socket & {
 	type?: ((user: core.Contract, card: core.Contract) => void) | undefined;
 };
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,7 @@
 import type { Socket } from 'socket.io-client';
 import type { core, JSONSchema } from '@balena/jellyfish-types';
 
-export type ExtendedSocket = typeof Socket & {
+export type ExtendedSocket = Socket & {
 	type?: ((user: core.Contract, card: core.Contract) => void) | undefined;
 };
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/jest": "^26.0.24",
     "@types/lodash": "^4.14.171",
     "@types/sinon": "^10.0.2",
-    "@types/socket.io-client": "^1.4.36",
+    "@types/socket.io-client": "^3.0.0",
     "@types/uuid": "^8.3.1",
     "depcheck": "^1.4.2",
     "deplint": "^1.1.3",


### PR DESCRIPTION
Change-type: major

***

In [docs](https://socket.io/docs/v3/emitting-events/):

> by default, the events are buffered until reconnection

We lose time waiting for stream connection.