### PR TITLE
Add support for authentication tokens

### DIFF
--- a/lib/auth.spec.ts
+++ b/lib/auth.spec.ts
@@ -1,0 +1,90 @@
+import Bluebird from 'bluebird';
+import nock from 'nock';
+import { getSdk, JellyfishSDK } from './index';
+
+let context: {
+	sdk: JellyfishSDK;
+	session: string;
+	token: string;
+	executeThenWait: (
+		asyncFn: any,
+		waitQuery: any,
+		times?: number,
+	) => Promise<any>;
+};
+
+const API_URL = 'https://test.ly.fish';
+
+beforeAll(async () => {
+	context = {
+		sdk: getSdk({
+			apiPrefix: 'api/v2',
+			apiUrl: API_URL,
+		}),
+		session: 'foobar-session',
+		token: 'foobar-token',
+		executeThenWait: async (asyncFn, waitQuery, times = 20) => {
+			if (times === 0) {
+				throw new Error('The wait query did not resolve');
+			}
+
+			if (asyncFn) {
+				await asyncFn();
+			}
+
+			const results = await context.sdk.query(waitQuery);
+			if (results.length > 0) {
+				return results[0];
+			}
+
+			await Bluebird.delay(1000);
+			return context.executeThenWait(null, waitQuery, times - 1);
+		},
+	};
+});
+
+beforeEach(() => {
+	nock.cleanAll();
+});
+
+afterEach(() => {
+	context.sdk.cancelAllStreams();
+	context.sdk.cancelAllRequests();
+});
+
+test('.login() should set both token and session ID correctly if they are present in the response', async () => {
+	const { sdk } = context;
+
+	const server = nock(API_URL);
+
+	const mockSessionId = context.session;
+	const mockAuthToken = context.token;
+
+	server.post(/action/).reply((_uri) => {
+		return [
+			200,
+			{
+				error: false,
+				data: {
+					id: mockSessionId,
+					data: {
+						token: {
+							authentication: mockAuthToken,
+						},
+					},
+					slug: 'session-user-jellyfish-1638973657394-45ea8952-6523-4be9-9f52-404480720cd3',
+					type: 'session@1.0.0',
+					version: '1.0.0',
+				},
+			},
+		];
+	});
+
+	await sdk.auth.login({
+		username: 'jellyfish',
+		password: 'jellyfish',
+	});
+
+	expect(sdk.getSessionId()).toEqual(mockSessionId);
+	expect(sdk.getAuthToken()).toEqual(mockAuthToken);
+});

--- a/lib/auth.spec.ts
+++ b/lib/auth.spec.ts
@@ -60,7 +60,7 @@ test('.login() should set both token and session ID correctly if they are presen
 	const mockSessionId = context.session;
 	const mockAuthToken = context.token;
 
-	server.post(/action/).reply((_uri) => {
+	server.post(/login/).reply((_uri) => {
 		return [
 			200,
 			{

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -105,13 +105,17 @@ export class AuthSdk {
 	 * 		console.log('Authenticated')
 	 * 	})
 	 */
-	public async loginWithToken(token: string): Promise<string> {
+	public async loginWithToken(
+		sessionId: string,
+		token: string | null = null,
+	): Promise<string> {
 		// Set the auth token
+		this.sdk.setSessionId(sessionId);
 		this.sdk.setAuthToken(token);
 
 		// Check to see if the token has expired
 		try {
-			const sessionContract = await this.sdk.card.get(token);
+			const sessionContract = await this.sdk.card.get(sessionId);
 			if (!sessionContract) {
 				throw new Error('Session could not be retrieved');
 			}
@@ -123,10 +127,11 @@ export class AuthSdk {
 				throw new Error('Token has expired');
 			}
 
-			return token;
+			return sessionId;
 		} catch (error) {
-			this.sdk.setAuthToken(null);
-			throw new Error(`Token is invalid: ${token}`);
+			this.sdk.clearSessionId();
+			this.sdk.clearAuthToken();
+			throw new Error(`Invalid session ID or token: ${token}`);
 		}
 	}
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -177,7 +177,12 @@ export class AuthSdk {
 			})
 			.then((response) => {
 				const session = response.data.data;
-				this.sdk.setAuthToken(session!.id);
+
+				if (session.data.token) {
+					this.sdk.setAuthToken((session!.data.token as any).authentication);
+				}
+				this.sdk.setSessionId(session!.id);
+
 				return session;
 			});
 	}
@@ -215,8 +220,10 @@ export class AuthSdk {
 				});
 			})
 			.then((session) => {
-				this.sdk.setAuthToken(session!.id);
-
+				if (session.data.token) {
+					this.sdk.setAuthToken((session!.data.token as any).authentication);
+				}
+				this.sdk.setSessionId(session!.id);
 				return session!.id;
 			});
 	}
@@ -235,6 +242,7 @@ export class AuthSdk {
 	 * sdk.auth.logout()
 	 */
 	public logout(): void {
+		this.sdk.clearSessionId();
 		this.sdk.clearAuthToken();
 		this.sdk.cancelAllRequests();
 		this.sdk.cancelAllStreams();

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -207,12 +207,14 @@ export class JellyfishSDK {
 	 * @returns {Promise}
 	 */
 	getFile = async (cardId: Contract['id'], name: string) => {
+		const headers = {
+			...this.defaultHeaders(),
+			accept: 'image/webp,image/*,*/*;q=0.8',
+		};
+
 		return (
 			await axios.get(`${this.API_BASE}file/${cardId}/${name}`, {
-				headers: {
-					authorization: `Bearer ${this.authToken}`,
-					accept: 'image/webp,image/*,*/*;q=0.8',
-				},
+				headers,
 				responseType: 'arraybuffer',
 			})
 		).data;
@@ -444,17 +446,7 @@ export class JellyfishSDK {
 		endpoint: string,
 		options?: AxiosRequestConfig,
 	): Promise<AxiosResponse<{ data: TResponse; error: Error }>> {
-		let headers = {};
-
-		if (this.sessionId && this.authToken) {
-			headers = {
-				authorization: `Bearer ${this.sessionId}.${this.authToken}`,
-			};
-		} else if (this.sessionId) {
-			headers = {
-				authorization: `Bearer ${this.sessionId}`,
-			};
-		}
+		const headers = this.defaultHeaders();
 
 		// Generate a fresh cancel token
 		const cancelTokenSource = axios.CancelToken.source();
@@ -716,7 +708,9 @@ export class JellyfishSDK {
 	async getByType<TContract extends Contract = Contract>(
 		type: string,
 	): Promise<TContract[]> {
-		const headers = this.defaultHeaders();
+		const options: any | undefined = {
+			...this.defaultHeaders(),
+		};
 
 		return (
 			await axios.get<TContract[]>(`${this.API_BASE}type/${type}`, options)
@@ -737,7 +731,9 @@ export class JellyfishSDK {
 	async getById<TContract extends Contract = Contract>(
 		id: Contract['id'],
 	): Promise<TContract | null> {
-		const headers = this.defaultHeaders();
+		const options: any | undefined = {
+			...this.defaultHeaders(),
+		};
 
 		try {
 			return (await axios.get<TContract>(`${this.API_BASE}id/${id}`, options))
@@ -764,7 +760,9 @@ export class JellyfishSDK {
 	async getBySlug<TContract extends Contract = Contract>(
 		slug: string,
 	): Promise<TContract | null> {
-		const headers = this.defaultHeaders();
+		const options: any | undefined = {
+			...this.defaultHeaders(),
+		};
 
 		try {
 			return (


### PR DESCRIPTION
This PR updates `jellyfish-client-sdk` to work with authentication tokens.

Changes:
- Expect and handle `data.token.authentication` returned from API on session creation;
- Change `Authentication` header contents to contain the session ID and token separated by a delimiter in case both values are available. Otherwise, this header will only contain the session ID, in order to guarantee backwards compatibility.

All changes were applied in such a way that the SDK remains compatible with the current version of API, and should work even if only the session ID is returned.

Depends on:
- https://github.com/product-os/jellyfish/pull/7473
- https://github.com/product-os/jellyfish-action-library/pull/1377