### PR TITLE
introduce retries for recoverable errors

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,6 +5,7 @@ import axios, {
 	AxiosResponse,
 	CancelTokenSource,
 } from 'axios';
+import axiosRetry from 'axios-retry';
 import {
 	forEach,
 	get,
@@ -34,6 +35,14 @@ const trimSlash = (text: string) => {
 const LINKS = constraints;
 
 export { constraints as linkConstraints, supportsLink, getReverseConstraint };
+
+axiosRetry(axios, {
+	retries: 3,
+	retryDelay: axiosRetry.exponentialDelay,
+	retryCondition: (err) =>
+		// retry network errors and transient http errors
+		!err.response || [502, 503, 504].includes(err.response.status),
+});
 
 /**
  * @summary Set the mask option to the supplied mask if it is set

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "axios": "^0.24.0",
+    "axios-retry": "^3.2.4",
     "common-tags": "^1.8.2",
     "deep-copy": "^1.4.2",
     "fast-json-patch": "^3.1.0",


### PR DESCRIPTION
we get so many failed Transformer builds because of 502 or 504s. This might help.

I didn't see a need to make this configurable for now, so it just defaults to max 3 retries with exp backoff