### PR TITLE
Streams: Fix bug that prevents stream initialisation

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -29,7 +29,7 @@ import {
 	getReverseConstraint,
 	supportsLink,
 } from './link-constraints';
-import { JellyfishStreamManager, StreamOptions } from './stream';
+import { JellyfishStreamManager } from './stream';
 import { ExtendedSocket, LinkConstraint, SdkQueryOptions } from './types';
 
 const trimSlash = (text: string) => {
@@ -844,7 +844,7 @@ export class JellyfishSDK {
 	 * 	console.error(error);
 	 * })
 	 */
-	stream(query: JsonSchema, options: StreamOptions = {}): ExtendedSocket {
+	stream(query: JsonSchema, options: SdkQueryOptions = {}): ExtendedSocket {
 		return this.streamManager.stream(query, options);
 	}
 
@@ -881,10 +881,7 @@ export class JellyfishSDK {
 	 *
 	 * const results = await cursor.nextPage()
 	 */
-	getCursor(
-		query: JsonSchema,
-		options: StreamOptions = { initialQuery: false },
-	): JellyfishCursor {
+	getCursor(query: JsonSchema, options: SdkQueryOptions): JellyfishCursor {
 		const socket = this.streamManager.stream(query, options);
 		return new JellyfishCursor(socket, query, options);
 	}


### PR DESCRIPTION
The initial `connect` reacton and `query` emission are vital for
correctly initialising the database stream correctly. I initially
changed this because I made the mistake that the `query` event caused
a full query to be run, which isn't the case.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>