### PR TITLE
Fix oauth response url path

### DIFF
--- a/lib/integrations.ts
+++ b/lib/integrations.ts
@@ -15,7 +15,7 @@ export class IntegrationsSdk {
 
 		const response = await this.sdk.get<{ url: string }>(endpoint);
 
-		return response?.data.data.url;
+		return response?.data.url;
 	}
 
 	async authorize(


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

While trying to get [this test](https://github.com/product-os/jellyfish/blob/6d28faa07cc497bff7fe3b7fb6d935f0686b28e9/test/e2e/ui/index.spec.js#L775) to pass, I was getting this error:
```
Page error: Error: TypeError: Cannot read properties of undefined (reading 'url') at IntegrationsSdk.eval (webpack://jellyfish-ui/./node_modules/@balena/jellyfish-client-sdk/build/integrations.js?:24:91)
```

Was able to resolve this error by applying the fix presented in this PR.