### PR TITLE
cursor: trim extra data items

### DIFF
--- a/lib/cursor.ts
+++ b/lib/cursor.ts
@@ -49,7 +49,8 @@ export class JellyfishCursor<T extends Contract = Contract> {
 		return new Promise((resolve) => {
 			const handler = ({ data }) => {
 				if (data.id === queryId) {
-					resolve(data.cards);
+					// Slice off any additional items that are returned for page detection
+					resolve(data.cards.slice(0, this.options.limit));
 					this.socket.off('dataset', handler);
 				}
 			};


### PR DESCRIPTION
When querying the API the cursor requests one additional item. This
overscan is used to see if there is another page of data available, but
shouldn't be returned to the callee. This change trims the data set to
the size of `options.limit` before returning it.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>