### PR TITLE
Simplify request code

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -31,9 +31,7 @@ export class AuthSdk {
 	public async whoami<
 		TContract extends Contract = Contract,
 	>(): Promise<TContract> {
-		return this.sdk.get<TContract>('/whoami').then((response) => {
-			return response.data.data;
-		});
+		return this.sdk.get<TContract>('/whoami');
 	}
 
 	/**

--- a/lib/integrations.ts
+++ b/lib/integrations.ts
@@ -12,18 +12,16 @@ export class IntegrationsSdk {
 		integration: string,
 	): Promise<string> {
 		const endpoint = `oauth/${integration}/${user.slug}`;
-
 		const response = await this.sdk.get<{ url: string }>(endpoint);
-
-		return response?.data.data.url;
+		return response.url;
 	}
 
 	async authorize(
 		user: Contract,
 		integration: string,
 		code: string,
-	): Promise<void> {
-		await this.sdk.post(`oauth/${integration}`, {
+	): Promise<any> {
+		return this.sdk.post(`oauth/${integration}`, {
 			slug: user.slug,
 			code,
 		});


### PR DESCRIPTION
Change-type: major

---

Call same `request` method from both `post` and `get` methods. Puts response handling in single place instead of duplicating it.