### PR TITLE
Make `jellyfish-core` a main dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "Apache-2.0",
   "dependencies": {
+    "@balena/jellyfish-core": "^15.0.0",
     "axios": "^0.26.0",
     "axios-retry": "^3.2.4",
     "common-tags": "^1.8.2",
@@ -55,7 +56,6 @@
   },
   "devDependencies": {
     "@balena/jellyfish-config": "^2.0.1",
-    "@balena/jellyfish-core": "^15.0.0",
     "@balena/jellyfish-types": "^2.0.4",
     "@balena/lint": "^6.2.0",
     "@types/common-tags": "^1.8.1",


### PR DESCRIPTION
The SDK exports a `SdkQueryOptions` type which extends from the core's `QueryOptions`, which means this dependency is not dev-only.

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>