### PR TITLE
Use autumndb instead of jellyfish-core

### DIFF
--- a/lib/card.ts
+++ b/lib/card.ts
@@ -1,4 +1,4 @@
-import type { QueryOptions } from '@balena/jellyfish-core';
+import type { QueryOptions } from 'autumndb';
 import type { JsonSchema } from '@balena/jellyfish-types';
 import type {
 	Contract,

--- a/lib/cursor.ts
+++ b/lib/cursor.ts
@@ -4,7 +4,7 @@
  * Proprietary and confidential.
  */
 
-import type { QueryOptions } from '@balena/jellyfish-core';
+import type { QueryOptions } from 'autumndb';
 import type { JsonSchema } from '@balena/jellyfish-types';
 import type { Contract } from '@balena/jellyfish-types/build/core';
 import { cloneDeep } from 'lodash';

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,4 +1,4 @@
-import type { errors as coreErrors } from '@balena/jellyfish-core';
+import type { errors as coreErrors } from 'autumndb';
 
 export class SDKRequestCancelledError
 	extends Error

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 /* global FormData */
-import type { QueryOptions } from '@balena/jellyfish-core';
+import type { QueryOptions } from 'autumndb';
 import type { JsonSchema } from '@balena/jellyfish-types';
 import type { Contract } from '@balena/jellyfish-types/build/core';
 import axios, { AxiosRequestConfig, CancelTokenSource } from 'axios';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,4 @@
-import type { QueryOptions } from '@balena/jellyfish-core';
+import type { QueryOptions } from 'autumndb';
 import type { Contract } from '@balena/jellyfish-types/build/core';
 import type { Socket } from 'socket.io-client';
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@balena/jellyfish-core": "^16.0.0",
+    "autumndb": "^17.0.3",
     "axios": "^0.26.1",
     "axios-retry": "^3.2.4",
     "common-tags": "^1.8.2",


### PR DESCRIPTION
The `jellyfish-core` package has been renamed to `autumndb`

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>