### PR TITLE
Remove automatic retries

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,6 @@ import type { QueryOptions } from 'autumndb';
 import type { JsonSchema } from '@balena/jellyfish-types';
 import type { Contract } from '@balena/jellyfish-types/build/core';
 import axios, { AxiosRequestConfig, CancelTokenSource } from 'axios';
-import axiosRetry from 'axios-retry';
 import {
 	forEach,
 	isBoolean,
@@ -39,14 +38,6 @@ export {
 	supportsLink,
 	getReverseConstraint,
 };
-
-axiosRetry(axios, {
-	retries: 3,
-	retryDelay: axiosRetry.exponentialDelay,
-	retryCondition: (err) =>
-		// retry network errors and transient http errors
-		!err.response || [502, 503, 504].includes(err.response.status),
-});
 
 /**
  * @summary Set the mask option to the supplied mask if it is set

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "autumndb": "^19.1.7",
     "axios": "^0.26.1",
-    "axios-retry": "^3.2.4",
     "common-tags": "^1.8.2",
     "deep-copy": "^1.4.2",
     "fast-json-patch": "^3.1.1",


### PR DESCRIPTION
Requests to Jellyfish are not currently idempotent, making automatic
retries unsafe. We've seen multiple incidents in production where
a non-200 HTTP status code is generated, but the contract has still been
correctly created, resulting in multiple entities being created.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>