### PR TITLE
Upgrade to AutumnDB v21.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "author": "Balena.io. <hello@balena.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "autumndb": "^20.3.3",
+    "autumndb": "^21.0.0",
     "axios": "^0.27.2",
     "common-tags": "^1.8.2",
     "deep-copy": "^1.4.2",


### PR DESCRIPTION
This brings in a major change to how AutumnDB handles sessions and
although it isn't a breaking change for the client SDK it is technically
incompatible with previous server versions.

See product-os/autumndb#1363

Change-type: major
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>