### PR TITLE
Change engines to >=16 to enable node 18 tests/usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/product-os/jellyfish-client-sdk.git"
   },
   "engines": {
-    "node": "^16.0.0"
+    "node": ">=16.0.0"
   },
   "description": "HTTP client SDK for Jellyfish",
   "main": "build/index.js",


### PR DESCRIPTION
Change-type: patch